### PR TITLE
fix: flatten phase cards from diagonal to horizontal row

### DIFF
--- a/bito-frontend/src/components/landing/sections/compass/CompassMock.tsx
+++ b/bito-frontend/src/components/landing/sections/compass/CompassMock.tsx
@@ -45,9 +45,9 @@ const PLAN_CARDS: PlanCard[] = [
 ]
 
 const CARD_FINAL_STATES: { rotate: number; x: number; y: number }[] = [
-  { rotate: -4, x: -200, y: 16 },
-  { rotate: 0, x: 0, y: -8 },
-  { rotate: 4, x: 200, y: 16 },
+  { rotate: 0, x: -210, y: 0 },
+  { rotate: 0, x: 0,    y: 0 },
+  { rotate: 0, x: 210,  y: 0 },
 ]
 
 interface CompassMockProps {
@@ -209,7 +209,7 @@ export function CompassMock({ start }: CompassMockProps) {
                   {card.phase}
                 </span>
                 <h4
-                  className="font-garamond mt-1 text-[18px]"
+                  className="font-garamond mt-1 text-[18px] font-semibold"
                   style={{ color: 'var(--color-text-primary)', margin: '4px 0 0 0' }}
                 >
                   {card.subtitle}

--- a/bito-frontend/src/landing.css
+++ b/bito-frontend/src/landing.css
@@ -79,8 +79,8 @@
    -------------------------------------------------------------------------- */
 [data-landing] .liquid-glass {
   background: rgba(26, 21, 53, 0.55);
-  backdrop-filter: blur(18px) saturate(140%);
-  -webkit-backdrop-filter: blur(18px) saturate(140%);
+  backdrop-filter: blur(12px) saturate(130%);
+  -webkit-backdrop-filter: blur(12px) saturate(130%);
   border: 1px solid var(--color-border-primary);
 }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `CARD_FINAL_STATES` in `CompassMock.tsx` had rotation values (`-4°`/`+4°`) and unequal y offsets (`16`/`-8`/`16`) that together produced the diagonal staircase appearance in the Compass section
- **Card layout**: Zeroed all `rotate` and `y` values so cards animate to the same baseline; set `x` offsets to `±210` for a flat side-by-side row with ~10px gaps
- **Typography**: Added `font-semibold` to the card subtitle `h4` to match the bolder headings in the reference design
- **Glassmorphism**: Reduced `liquid-glass` blur from `18px → 12px` and saturation from `140% → 130%` — the heavy blur was visually amplifying the diagonal stagger

## Files changed

- `bito-frontend/src/components/landing/sections/compass/CompassMock.tsx` — `CARD_FINAL_STATES` array + `h4` className
- `bito-frontend/src/landing.css` — `[data-landing] .liquid-glass` backdrop-filter values

## Test plan

- [ ] Run `npm run dev` in `bito-frontend/`
- [ ] Navigate to the landing page and scroll to the Compass section
- [ ] Confirm the three phase cards animate in flat and side-by-side (no tilt, no vertical stagger)
- [ ] Confirm card headings are visibly bolder
- [ ] Confirm glass cards still have a frosted look (softer, not removed)
- [ ] Check layout at narrow viewports — if cards clip, reduce `x` offsets from `±210` to `±200`

🤖 Generated with [Claude Code](https://claude.com/claude-code)